### PR TITLE
Add .pdf to filename.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,8 @@
 	},
 	"permissions": [
 		"menus",
-		"storage"
+		"storage",
+		"tabs"
 	],
 	"icons": {
 		"256": "icons/save-pdf-256-light.png"

--- a/save-to-pdf-now-background.js
+++ b/save-to-pdf-now-background.js
@@ -71,11 +71,12 @@ browser.storage.onChanged.addListener((changes, areaName) => {
 
 // Listen for button click and show popup
 browser.browserAction.onClicked.addListener((currTab, clickData) => {
+
 	// Check for Shift key to modify preferences
 	if (oPDFPrefs.shiftToPrint == true){
 		if (clickData.modifiers.includes('Shift')){
 			// Make the PDF
-			makePDF();
+			makePDF(currTab.title);
 		} else {
 			// Open popup
 			browser.browserAction.setPopup({popup: browser.runtime.getURL('save-to-pdf-now-popup.html')})
@@ -90,12 +91,13 @@ browser.browserAction.onClicked.addListener((currTab, clickData) => {
 			.then(browser.browserAction.setPopup({popup: ''}));
 		} else {
 			// Make the PDF
-			makePDF();
+			makePDF(currTab.title);
 		}
 	}
 });
 
-function makePDF() {
+function makePDF(title) {
+
 	// Make that PDF
 	if (oPDFPrefs.override == false){
 		// Do not send custom settings
@@ -156,6 +158,10 @@ function makePDF() {
 		if (oPDFPrefs.footerRightOverride == true){
 			pageSettings.footerRight = oPDFPrefs.footerRightText;
 		}
+
+		pageSettings.toFileName = title + '.pdf';
+		console.log(pageSettings);
+
 		// We're ready to go!
 		browser.tabs.saveAsPDF(pageSettings);
 	}

--- a/save-to-pdf-now-popup.js
+++ b/save-to-pdf-now-popup.js
@@ -153,6 +153,7 @@ updtPrefs.then(() => {
 
 // Button functions
 function saveAsPDF(evt){
+
 	// Update PDF prefs and keep track of changes for potential saving to storage
 	var frm = evt.target.form;
 	var changed = false;
@@ -442,9 +443,21 @@ function saveAsPDF(evt){
 		if (oPDFPrefs.footerRightOverride == true){
 			pageSettings.footerRight = oPDFPrefs.footerRightText;
 		}
-		// We're ready to go!
-		console.log(pageSettings);				
-		browser.tabs.saveAsPDF(pageSettings);
+
+        title = 'untitled'
+        browser.tabs.query({currentWindow: true, active:true})
+            .then(tabs => {
+                title += tabs[0].title;
+                console.log('title', tabs[0].title);
+
+                pageSettings.toFileName = title + '.pdf';
+
+                // We're ready to go!
+                console.log(pageSettings);
+
+                browser.tabs.saveAsPDF(pageSettings);
+        });
+
 	}
 }
 document.getElementById('btnSaveGo').addEventListener('click', saveAsPDF, false);


### PR DESCRIPTION
Hey, I love the plugin. Thanks for putting it together!

In macOS, I had the problem that FF didn't add `.pdf` to the filename. Doing this manually sort of negates the time saving of the addon. 

There doesn't seem to be any control over this in the `browser.tabs` API, so I did some hacking to get the tab title and set the filename manually. It seems like FF does the filename sanitization afterwards, so the result is the same as the native approach (I think). 

It isn't too pretty, but it works for me. 